### PR TITLE
Checks for null on setting adapter name

### DIFF
--- a/android/src/main/kotlin/com/keysking/k_ble_peripheral/AdvertisingHandler.kt
+++ b/android/src/main/kotlin/com/keysking/k_ble_peripheral/AdvertisingHandler.kt
@@ -46,7 +46,8 @@ class AdvertisingHandler(context: Context) : MethodCallHandler {
         // 扫描回包数据
         val scanResponse = scanResponseData.toAdvertiseData()
 
-        adapter.name = advertiseSettings.name
+        if(advertiseSettings.name != null)
+            adapter.name = advertiseSettings.name
 
         val callback = KAdvertiseCallback(result, id)
         advertiseCallbackMap[id] = callback


### PR DESCRIPTION
Thank you for creating this package!

This pull request simply adds a check for if there is no `name` set for `KAdvertisingSetting`. The field is listed as optional in the documentation but `startAdvertising` will crash with a null pointer exception if left out. It will now simply not set a name if it is not given, which will instead result in the previous name the system had being kept.

Tested on Google Pixel 5a.